### PR TITLE
[TestLogger] Use `Take` to freeze the length of returned enumerables.

### DIFF
--- a/FiftyOne.Common.TestHelpers/TestLogger.cs
+++ b/FiftyOne.Common.TestHelpers/TestLogger.cs
@@ -91,19 +91,24 @@ namespace FiftyOne.Common.TestHelpers
         /// <summary>
         /// List of log entries sent to the logger. 
         /// </summary>
-        public IReadOnlyList<ExtendedLogEntry> ExtendedEntries => _entries;
+        public IReadOnlyList<ExtendedLogEntry> ExtendedEntries => CurrentEntries.ToList();
+        
+        /// <summary>
+        /// Locks the length of the collection to allow mutations during enumeration without causing exception.
+        /// </summary>
+        private IEnumerable<ExtendedLogEntry> CurrentEntries => _entries.Take(_entries.Count);
 
         /// <summary>
         /// List of log entries sent to the logger. 
         /// </summary>
         public IReadOnlyList<KeyValuePair<LogLevel, string>> Entries 
-            => _entries.Select(t => new KeyValuePair<LogLevel, string>(t.LogLevel, t.Message)).ToList();
+            => CurrentEntries.Select(t => new KeyValuePair<LogLevel, string>(t.LogLevel, t.Message)).ToList();
 
         /// <summary>
         /// Convenience filter for convenience properties. 
         /// </summary>
         private IEnumerable<string> GetMessages(LogLevel logLevel)
-            => _entries.Where(i => i.LogLevel == logLevel).Select(i => i.Message);
+            => CurrentEntries.Where(i => i.LogLevel == logLevel).Select(i => i.Message);
 
         /// <summary>
         /// Enumerable of the text of critical entries that have been logged.


### PR DESCRIPTION
### Motivation:

Prevent the following error during unit tests:
> System.InvalidOperationException: Collection was modified; enumeration operation may not execute.

Log example:
https://github.com/postindustria-tech/pipeline-dotnet/actions/runs/6432112796/job/17469553377#step:5:819

### Solution proof:

The following code:
```cs
var c = new int[] { 5, 17 }.ToList();
var z = c.Take(c.Count);
c.Add(29);
foreach (var i in z)
{
    Console.WriteLine($"{nameof(i)} = {i}");
    c.Add(2 * i);
}
foreach (var j in c)
{
    Console.WriteLine($"{nameof(j)} = {j}");
}
```
results in:
```
i = 5
i = 17
j = 5
j = 17
j = 29
j = 10
j = 34
```
^ which illustrates that it is safe to append to a collection behind [Take](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.take?view=netstandard-2.0) both (a) between getting and enumeration and (b) during enumeration itself.