### PR TITLE
Add Project URL into Nuget package

### DIFF
--- a/FiftyOne.Common.TestHelpers/FiftyOne.Common.TestHelpers.csproj
+++ b/FiftyOne.Common.TestHelpers/FiftyOne.Common.TestHelpers.csproj
@@ -17,6 +17,7 @@
 	<Copyright>51Degrees Mobile Experts Limited</Copyright>
 	<PackageTags>51degrees</PackageTags>
 	<RepositoryUrl>https://github.com/51Degrees/common-dotnet</RepositoryUrl>
+	<PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/FiftyOne.Common/FiftyOne.Common.csproj
+++ b/FiftyOne.Common/FiftyOne.Common.csproj
@@ -17,6 +17,7 @@
 	<Copyright>51Degrees Mobile Experts Limited</Copyright>
 	<PackageTags>51degrees</PackageTags>
 	<RepositoryUrl>https://github.com/51Degrees/common-dotnet</RepositoryUrl>
+	<PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
### Changes
- Set `PackageProjectUrl` to `https://51degrees.com`.

### Why
- https://github.com/51Degrees/device-detection-dotnet/issues/169