### PR TITLE
FEAT: Added wrapper service for calling an HTTP dependency.

### DIFF
--- a/FiftyOne.Common.Test/FiftyOne.Common.Test.csproj
+++ b/FiftyOne.Common.Test/FiftyOne.Common.Test.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FiftyOne.Common.TestHelpers\FiftyOne.Common.TestHelpers.csproj" />
+    <ProjectReference Include="..\FiftyOne.Common\FiftyOne.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/FiftyOne.Common.Test/LimitedHttpClientTests.cs
+++ b/FiftyOne.Common.Test/LimitedHttpClientTests.cs
@@ -1,0 +1,343 @@
+using FiftyOne.Common.Services;
+using FiftyOne.Common.TestHelpers;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Moq;
+using System.Net;
+
+namespace FiftyOne.Common.Test
+{
+    [TestClass]
+    public class LimitedHttpClientTests
+    {
+        private TestLoggerFactory _loggerFactory;
+
+        /// <summary>
+        /// Test handler class to simulate an HTTP service.
+        /// </summary>
+        private class TestHttpHandler : HttpMessageHandler
+        {
+            private readonly Func<string, Task<string>> _getResponse;
+
+            public HttpClient Client => new HttpClient(this);
+
+            public int Requests { get; private set; }
+
+            public TestHttpHandler(Func<string, Task<string>> getResponse)
+            {
+                _getResponse = getResponse;
+                Requests = 0;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                Requests = Requests + 1;
+                var response = await _getResponse(request.RequestUri?.ToString());
+                var result = new HttpResponseMessage(HttpStatusCode.OK);
+                result.Content = new StringContent(response);
+                return result;
+            }
+        }
+
+        [TestInitialize]
+        public void Init()
+        {
+            _loggerFactory = new TestLoggerFactory();
+        }
+
+        /// <summary>
+        /// Check that a single request is passed to the underlying service
+        /// correctly.
+        /// </summary>
+        /// <param name="method"></param>
+        [DataRow("GET")]
+        [DataRow("POST")]
+        [DataTestMethod]
+        public void SingleRequest(string method)
+        {
+            // Arrange
+            var expectedResult = "some string...";
+            var handler = new TestHttpHandler((s) => Task.FromResult(expectedResult));
+            var limiter = new LimitedHttpClientWrapper(
+                _loggerFactory.CreateLogger<LimitedHttpClientWrapper>(),
+                handler.Client,
+                1);
+
+            // Act
+            Task<HttpResponseMessage> result = null;
+            switch (method)
+            {
+                case "GET":
+                    result = limiter.GetAsync("http://51degrees.com", CancellationToken.None);
+                    break;
+                case "POST":
+                    result = limiter.PostAsync("https://51degrees.com", null, CancellationToken.None);
+                    break;
+            }
+
+            // Assert
+            Assert.IsTrue(result.IsCompletedSuccessfully);
+            Assert.IsNotNull(result.Result.Content.ReadAsStringAsync().Result);
+            Assert.AreEqual(expectedResult, result.Result.Content.ReadAsStringAsync().Result);
+            AssertNoRemainingRequests(limiter);
+        }
+
+        /// <summary>
+        /// Check that multiple requests are passed to the underlying service
+        /// correctly when there are less than the specified number of max
+        /// concurrent requests.
+        /// </summary>
+        /// <param name="method"></param>
+        [DataRow("GET")]
+        [DataRow("POST")]
+        [DataTestMethod]
+        public void MultipleRequests(string method)
+        {
+            // Arrange
+            var expectedResult = "some string...";
+            var handler = new TestHttpHandler((s) => Task.FromResult(expectedResult));
+            var limiter = new LimitedHttpClientWrapper(
+                _loggerFactory.CreateLogger<LimitedHttpClientWrapper>(),
+                handler.Client,
+                2);
+
+            // Act
+            Task<HttpResponseMessage> result1 = null;
+            Task<HttpResponseMessage> result2 = null;
+            switch (method)
+            {
+                case "GET":
+                    result1 = limiter.GetAsync("http://51degrees.com", CancellationToken.None);
+                    result2 = limiter.GetAsync("http://51degrees.com", CancellationToken.None);
+                    break;
+                case "POST":
+                    result1 = limiter.PostAsync("https://51degrees.com", null, CancellationToken.None);
+                    result2 = limiter.PostAsync("https://51degrees.com", null, CancellationToken.None);
+                    break;
+            }
+
+            // Assert
+            Assert.IsTrue(result1.IsCompletedSuccessfully);
+            Assert.IsNotNull(result1.Result.Content.ReadAsStringAsync().Result);
+            Assert.AreEqual(expectedResult, result1.Result.Content.ReadAsStringAsync().Result);
+            Assert.IsTrue(result2.IsCompletedSuccessfully);
+            Assert.IsNotNull(result2.Result.Content.ReadAsStringAsync().Result);
+            Assert.AreEqual(expectedResult, result2.Result.Content.ReadAsStringAsync().Result);
+            AssertNoRemainingRequests(limiter);
+        }
+
+        /// <summary>
+        /// Check that requests over the limit of concurrent requests return
+        /// null, and do not call the underlying service.
+        /// This is done by setting the response function used by the mock
+        /// service to loop until a token is set, keeping a request active
+        /// while a second request is made.
+        /// </summary>
+        /// <param name="method"></param>
+        [DataRow("GET")]
+        [DataRow("POST")]
+        [DataTestMethod]
+        public void MultipleRequests_Limited(string method)
+        {
+            // Arrange
+            var expectedResult = "some string...";
+            var token = new CancellationTokenSource();
+            var handler = new TestHttpHandler((s) => Task.Run(() =>
+            {
+                while (token.Token.IsCancellationRequested == false)
+                {
+                    Task.Delay(1);
+                }
+                return expectedResult;
+            }));
+            var limiter = new LimitedHttpClientWrapper(
+                _loggerFactory.CreateLogger<LimitedHttpClientWrapper>(),
+                handler.Client,
+                1);
+
+            // Act
+            Task<HttpResponseMessage> result1 = null;
+            Task<HttpResponseMessage> result2 = null;
+            switch (method)
+            {
+                case "GET":
+                    result1 = limiter.GetAsync("http://51degrees.com", CancellationToken.None);
+                    // Make the second request while the first is still in
+                    // progress, then complete the first.
+                    result2 = limiter.GetAsync("http://51degrees.com", CancellationToken.None);
+                    break;
+                case "POST":
+                    result1 = limiter.PostAsync("http://51degrees.com", null, CancellationToken.None);
+                    // Make the second request while the first is still in
+                    // progress, then complete the first.
+                    result2 = limiter.PostAsync("http://51degrees.com", null, CancellationToken.None);
+                    break;
+            }
+
+            token.Cancel();
+
+            // Assert
+            result1.Wait();
+            Assert.IsTrue(result1.IsCompletedSuccessfully);
+            Assert.IsNotNull(result1.Result.Content.ReadAsStringAsync().Result);
+            Assert.AreEqual(expectedResult, result1.Result.Content.ReadAsStringAsync().Result);
+            Assert.IsTrue(result2.IsCompletedSuccessfully);
+            Assert.IsNull(result2.Result);
+            AssertNoRemainingRequests(limiter);
+            Assert.AreEqual(1, handler.Requests);
+        }
+
+        /// <summary>
+        /// Check that the correct responses are returned for each request.
+        /// This ensures that tasks are not mixed up somehow.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <exception cref="Exception"></exception>
+        [DataRow("GET")]
+        [DataRow("POST")]
+        [DataTestMethod]
+        public void MultipleRequests_DifferentResults(string method)
+        {
+            // Arrange
+            var expectedResult1 = "some string...";
+            var expectedResult2 = "some other string...";
+            var handler = new TestHttpHandler((s) =>
+            {
+                if (s.EndsWith("1"))
+                {
+                    return Task.FromResult(expectedResult1);
+                }
+                else if (s.EndsWith("2"))
+                {
+                    return Task.FromResult(expectedResult2);
+                }
+                else { throw new Exception(); }
+            });
+            var limiter = new LimitedHttpClientWrapper(
+                _loggerFactory.CreateLogger<LimitedHttpClientWrapper>(),
+                handler.Client,
+                2);
+
+            // Act
+            Task<HttpResponseMessage> result1 = null;
+            Task<HttpResponseMessage> result2 = null;
+            switch (method)
+            {
+                case "GET":
+                    result1 = limiter.GetAsync("http://51degrees.com/1", CancellationToken.None);
+                    result2 = limiter.GetAsync("http://51degrees.com/2", CancellationToken.None);
+                    break;
+                case "POST":
+                    result1 = limiter.PostAsync("https://51degrees.com/1", null, CancellationToken.None);
+                    result2 = limiter.PostAsync("https://51degrees.com/2", null, CancellationToken.None);
+                    break;
+            }
+
+            // Assert
+            result1.Wait();
+            Assert.IsTrue(result1.IsCompletedSuccessfully);
+            Assert.IsNotNull(result1.Result.Content.ReadAsStringAsync().Result);
+            Assert.AreEqual(expectedResult1, result1.Result.Content.ReadAsStringAsync().Result);
+            Assert.IsTrue(result2.IsCompletedSuccessfully);
+            Assert.IsNotNull(result2.Result.Content.ReadAsStringAsync().Result);
+            Assert.AreEqual(expectedResult2, result2.Result.Content.ReadAsStringAsync().Result);
+            AssertNoRemainingRequests(limiter);
+            Assert.AreEqual(2, handler.Requests);
+        }
+
+        /// <summary>
+        /// Check that requests made after the limit has been exceeded, then
+        /// cleared down below the limit, call the underlying service
+        /// correctly.
+        /// This is done by setting the response function used by the mock
+        /// service to loop until a token is set, keeping a request active
+        /// while a second request is made. The token is then set so that the
+        /// first request can complete, then a third request is made.
+        /// Outcome should be:
+        /// request 1 - succeed
+        /// request 2 - fail
+        /// request 3 - succeed
+        /// </summary>
+        /// <param name="method"></param>
+        [DataRow("GET")]
+        [DataRow("POST")]
+        [DataTestMethod]
+        public void MultipleRequests_PreviouslyLimited(string method)
+        {
+            // Arrange
+            var expectedResult = "some string...";
+            var token = new CancellationTokenSource();
+            var handler = new TestHttpHandler((s) => Task.Run(() =>
+            {
+                while (token.Token.IsCancellationRequested == false)
+                {
+                    Task.Delay(1);
+                }
+                return expectedResult;
+            }));
+            var limiter = new LimitedHttpClientWrapper(
+                _loggerFactory.CreateLogger<LimitedHttpClientWrapper>(),
+                handler.Client,
+                1);
+
+            // Act
+            Task<HttpResponseMessage> result1 = null;
+            Task<HttpResponseMessage> result2 = null;
+            Task<HttpResponseMessage> result3 = null;
+            switch (method)
+            {
+                case "GET":
+                    result1 = limiter.GetAsync("http://51degrees.com", CancellationToken.None);
+                    // Make the second request while the first is still in
+                    // progress, then complete the first.
+                    result2 = limiter.GetAsync("http://51degrees.com", CancellationToken.None);
+                    token.Cancel();
+                    Thread.Sleep(10);
+                    result3 = limiter.GetAsync("http://51degrees.com", CancellationToken.None);
+                    break;
+                case "POST":
+                    result1 = limiter.PostAsync("http://51degrees.com", null, CancellationToken.None);
+                    // Make the second request while the first is still in
+                    // progress, then complete the first.
+                    result2 = limiter.PostAsync("http://51degrees.com", null, CancellationToken.None);
+                    token.Cancel();
+                    Thread.Sleep(10);
+                    result3 = limiter.PostAsync("http://51degrees.com", null, CancellationToken.None);
+                    break;
+            }
+
+            // Assert
+            result3.Wait();
+            Assert.IsTrue(result1.IsCompletedSuccessfully);
+            Assert.IsNotNull(result1.Result.Content.ReadAsStringAsync().Result);
+            Assert.AreEqual(expectedResult, result1.Result.Content.ReadAsStringAsync().Result);
+            Assert.IsTrue(result2.IsCompletedSuccessfully);
+            Assert.IsNull(result2.Result);
+            Assert.IsTrue(result3.IsCompletedSuccessfully);
+            Assert.IsNotNull(result3.Result.Content.ReadAsStringAsync().Result);
+            Assert.AreEqual(expectedResult, result3.Result.Content.ReadAsStringAsync().Result);
+            AssertNoRemainingRequests(limiter);
+            Assert.AreEqual(2, handler.Requests);
+        }
+
+
+        /// <summary>
+        /// Asserts that there are no current requests in the serivce.
+        /// Retries 10 times over 10ms to ensure the "Continue" tasks
+        /// have also completed.
+        /// </summary>
+        /// <param name="limiter"></param>
+        private void AssertNoRemainingRequests(LimitedHttpClientWrapper limiter)
+        {
+            int count = 0;
+            while (count < 10 && limiter.CurrentRequests > 0)
+            {
+                count++;
+                Thread.Sleep(1);
+            }
+            Assert.AreEqual(0, limiter.CurrentRequests);
+        }
+    }
+}

--- a/FiftyOne.Common.TestHelpers/FiftyOne.Common.TestHelpers.csproj
+++ b/FiftyOne.Common.TestHelpers/FiftyOne.Common.TestHelpers.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.1" />
   </ItemGroup>
 
 </Project>

--- a/FiftyOne.Common.sln
+++ b/FiftyOne.Common.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FiftyOne.Common", "FiftyOne.Common\FiftyOne.Common.csproj", "{DE342225-B038-4057-B0BB-D1586BDF5658}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FiftyOne.Common.TestHelpers", "FiftyOne.Common.TestHelpers\FiftyOne.Common.TestHelpers.csproj", "{3BFA24C1-973E-4D5F-8F20-A19171E349F8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FiftyOne.Common.Test", "FiftyOne.Common.Test\FiftyOne.Common.Test.csproj", "{5A27B65D-055D-40A4-BD7F-3E696A684610}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{3BFA24C1-973E-4D5F-8F20-A19171E349F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BFA24C1-973E-4D5F-8F20-A19171E349F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BFA24C1-973E-4D5F-8F20-A19171E349F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A27B65D-055D-40A4-BD7F-3E696A684610}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A27B65D-055D-40A4-BD7F-3E696A684610}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A27B65D-055D-40A4-BD7F-3E696A684610}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A27B65D-055D-40A4-BD7F-3E696A684610}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FiftyOne.Common/FiftyOne.Common.csproj
+++ b/FiftyOne.Common/FiftyOne.Common.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.Github" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/FiftyOne.Common/Services/HttpClientWrapper.cs
+++ b/FiftyOne.Common/Services/HttpClientWrapper.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FiftyOne.Common.Services
+{
+    /// <summary>
+    /// Default implementation of IHttpClientWrapper.
+    /// This is a simple wrapper which just calls straight to
+    /// the client.
+    /// </summary>
+    public class HttpClientWrapper : IHttpClientWrapper
+    {
+        private readonly HttpClient _client;
+
+        public HttpClientWrapper(HttpClient httpClient)
+        {
+            _client = httpClient;
+        }
+        public Task<HttpResponseMessage> GetAsync(
+            string requestUri,
+            CancellationToken cancellationToken)
+        {
+            return _client.GetAsync(requestUri, cancellationToken);
+        }
+
+        public Task<HttpResponseMessage> PostAsync(
+            string uri,
+            HttpContent content,
+            CancellationToken cancellationToken)
+        {
+            return _client.PostAsync(uri, content, cancellationToken);
+        }
+    }
+}

--- a/FiftyOne.Common/Services/IHttpClientWrapper.cs
+++ b/FiftyOne.Common/Services/IHttpClientWrapper.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FiftyOne.Common.Services
+{
+    /// <summary>
+    /// Wrapper for an HttpClient instance.
+    /// An implementation can do various things, such as
+    /// limit the number of concurrent requests.
+    /// </summary>
+    public interface IHttpClientWrapper
+    {
+        /// <summary>
+        /// Calls <see cref="HttpClient.GetAsync(string, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="requestUri"></param>
+        /// <returns></returns>
+        Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Calls <see cref="HttpClient.PostAsync(string, HttpContent, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <param name="content"></param>
+        /// <returns></returns>
+        Task<HttpResponseMessage> PostAsync(string uri, HttpContent content, CancellationToken cancellationToken);
+    }
+}

--- a/FiftyOne.Common/Services/LimitedHttpClientWrapper.cs
+++ b/FiftyOne.Common/Services/LimitedHttpClientWrapper.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FiftyOne.Common.Services
+{
+    /// <summary>
+    /// Wrapper which limits the number of concurrent requests
+    /// to the HttpClient. Requests made which would take the number
+    /// of active requests over the limit will not be processed, and
+    /// instead return a null response.
+    /// </summary>
+    public class LimitedHttpClientWrapper : IHttpClientWrapper
+    {
+        private readonly ILogger<LimitedHttpClientWrapper> _logger;
+        private readonly HttpClient _client;
+        private readonly int _maxConcurrent;
+        private readonly ConcurrentDictionary<int, Task> _requests;
+
+        /// <summary>
+        /// Number of current requests that are being processed.
+        /// Note that there may be a slight delay (no more than a millisecond
+        /// or two) as the removal relies on a continuation.
+        /// </summary>
+        public int CurrentRequests => _requests.Count;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="logger">
+        /// Logger to use for errors.
+        /// </param>
+        /// <param name="httpClient">
+        /// HttpClient to call.
+        /// </param>
+        /// <param name="maxConcurrent">
+        /// Maximum number of requests to allow simultaniously.
+        /// </param>
+        public LimitedHttpClientWrapper(
+            ILogger<LimitedHttpClientWrapper> logger,
+            HttpClient httpClient,
+            int maxConcurrent)
+        {
+            _logger = logger;
+            _client = httpClient;
+            _maxConcurrent = maxConcurrent;
+            _requests = new ConcurrentDictionary<int, Task>();
+        }
+
+        public Task<HttpResponseMessage> GetAsync(
+            string requestUri,
+            CancellationToken cancellationToken)
+        {
+            return WrapRequest(() => _client.GetAsync(requestUri, cancellationToken));
+        }
+
+        public Task<HttpResponseMessage> PostAsync(
+            string uri,
+            HttpContent content,
+            CancellationToken cancellationToken)
+        {
+            return WrapRequest(() => _client.PostAsync(uri, content, cancellationToken));
+        }
+
+        /// <summary>
+        /// Wraps a request to the client with logic to limit.
+        /// </summary>
+        /// <param name="getResponse">
+        /// Function to call the client, either GET or POST.
+        /// </param>
+        /// <returns>
+        /// Result of the getResponse function, or null.
+        /// </returns>
+        /// <exception cref="Exception">
+        /// If a request could not be added to the dictionary.
+        /// </exception>
+        private Task<HttpResponseMessage> WrapRequest(
+            Func<Task<HttpResponseMessage>> getResponse)
+        {
+            if (_requests.Count < _maxConcurrent)
+            {
+                var request = getResponse();
+                if (_requests.TryAdd(request.Id, request) == false)
+                {
+                    throw new Exception("Failed to add request.");
+                }
+                request.ContinueWith(t =>
+                {
+                    if (_requests.TryRemove(request.Id, out var removed) == false)
+                    {
+                        _logger.LogError("Failed to remove completed request.");
+                    }
+                });
+                return request;
+            }
+            else
+            {
+                return Task.FromResult<HttpResponseMessage>(null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The main use case for this is to limit the number of concurrent requests to a service to avoid exhausting the socket pool.