### PR TITLE
REORG: Move test helper methods to common

### DIFF
--- a/FiftyOne.Common.TestHelpers/TestUtils.cs
+++ b/FiftyOne.Common.TestHelpers/TestUtils.cs
@@ -1,0 +1,44 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace FiftyOne.Common.TestHelpers
+{
+    public static class TestUtils
+    {
+        public static FileInfo GetFilePath(string filename, DirectoryInfo searchRoot)
+        {
+            var p = FileUtils.FindFile(filename, searchRoot);
+            var fullPath = p == null ? null : new FileInfo(p);
+            
+            if (fullPath == null || fullPath.Exists == false)
+            {
+                Assert.Inconclusive($"Expected data file " +
+                                    $"'{filename}' was missing. Test not run.");
+            }
+            return fullPath;
+        }
+    }
+}

--- a/FiftyOne.Common.TestHelpers/TestUtils.cs
+++ b/FiftyOne.Common.TestHelpers/TestUtils.cs
@@ -21,14 +21,15 @@
  * ********************************************************************* */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.IO;
 
 namespace FiftyOne.Common.TestHelpers
 {
     public static class TestUtils
     {
-        public static FileInfo GetFilePath(string filename, DirectoryInfo searchRoot)
+        public static FileInfo GetFilePath(
+            string filename,
+            DirectoryInfo searchRoot)
         {
             var p = FileUtils.FindFile(filename, searchRoot);
             var fullPath = p == null ? null : new FileInfo(p);

--- a/FiftyOne.Common/FileUtils.cs
+++ b/FiftyOne.Common/FileUtils.cs
@@ -20,7 +20,6 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,15 +34,16 @@ namespace FiftyOne.Common
         private const int FindFileTimeoutMs = 10000;
 
         /// <summary>
-        /// Uses a background task to search for the specified filename within the working 
-        /// directory.
-        /// If the file cannot be found, the algorithm will move to the parent directory and 
-        /// repeat the process.
+        /// Uses a background task to search for the specified filename within
+        /// the working directory.
+        /// If the file cannot be found, the algorithm will move to the parent
+        /// directory and repeat the process.
         /// This continues until the file is found or a timeout is triggered.
         /// </summary>
         /// <param name="filename"></param>
         /// <param name="dir">
-        /// The directory to start looking from. If not provided the current directory is used.
+        /// The directory to start looking from. If not provided the current
+        /// directory is used.
         /// </param>
         /// <returns></returns>
         public static string FindFile(
@@ -52,7 +52,10 @@ namespace FiftyOne.Common
         {
             var cancel = new CancellationTokenSource();
             // Start the file system search as a separate task.
-            var searchTask = Task.Run(() => FindFile(filename, dir, cancel.Token));
+            var searchTask = Task.Run(() => FindFile(
+                filename, 
+                dir, 
+                cancel.Token));
             // Wait for either the search or a timeout task to complete.
             Task.WaitAny(searchTask, Task.Delay(FindFileTimeoutMs));
             cancel.Cancel();
@@ -73,7 +76,9 @@ namespace FiftyOne.Common
 
             try
             {
-                var files = dir.GetFiles(filename, SearchOption.AllDirectories);
+                var files = dir.GetFiles(
+                    filename, 
+                    SearchOption.AllDirectories);
                 if (files.Length == 0 &&
                     dir.Parent != null &&
                     cancel.IsCancellationRequested == false)

--- a/FiftyOne.Common/FileUtils.cs
+++ b/FiftyOne.Common/FileUtils.cs
@@ -1,0 +1,95 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FiftyOne.Common
+{
+    public static class FileUtils
+    {
+        /// <summary>
+        /// Timeout used when searching for files.
+        /// </summary>
+        private const int FindFileTimeoutMs = 10000;
+
+        /// <summary>
+        /// Uses a background task to search for the specified filename within the working 
+        /// directory.
+        /// If the file cannot be found, the algorithm will move to the parent directory and 
+        /// repeat the process.
+        /// This continues until the file is found or a timeout is triggered.
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <param name="dir">
+        /// The directory to start looking from. If not provided the current directory is used.
+        /// </param>
+        /// <returns></returns>
+        public static string FindFile(
+            string filename,
+            DirectoryInfo dir = null)
+        {
+            var cancel = new CancellationTokenSource();
+            // Start the file system search as a separate task.
+            var searchTask = Task.Run(() => FindFile(filename, dir, cancel.Token));
+            // Wait for either the search or a timeout task to complete.
+            Task.WaitAny(searchTask, Task.Delay(FindFileTimeoutMs));
+            cancel.Cancel();
+            // If search has not got a result then return null.
+            return searchTask.IsCompleted ? searchTask.Result : null;
+        }
+
+        private static string FindFile(
+            string filename,
+            DirectoryInfo dir,
+            CancellationToken cancel)
+        {
+            if (dir == null)
+            {
+                dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+            }
+            string result = null;
+
+            try
+            {
+                var files = dir.GetFiles(filename, SearchOption.AllDirectories);
+                if (files.Length == 0 &&
+                    dir.Parent != null &&
+                    cancel.IsCancellationRequested == false)
+                {
+                    result = FindFile(filename, dir.Parent, cancel);
+                }
+                else if (files.Length > 0)
+                {
+                    result = files[0].FullName;
+                }
+            }
+            // No matter what goes wrong here, we just want to indicate that we
+            // couldn't find the file by returning null.
+            catch { result = null; }
+
+            return result;
+        }
+    }
+}

--- a/FiftyOne.Common/KeyUtils.cs
+++ b/FiftyOne.Common/KeyUtils.cs
@@ -1,0 +1,61 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System;
+using System.Text;
+
+namespace FiftyOne.Common
+{
+    public static class KeyUtils
+    {
+        /// <summary>
+        /// Checks if the supplied 51Degrees resource key / license key is invalid.
+        /// Note that this cannot determine if the key is definitely valid, just whether it is
+        /// definitely invalid.
+        /// </summary>
+        /// <param name="key">
+        /// The key to check.
+        /// </param>
+        /// <returns></returns>
+        public static bool IsInvalidKey(string key)
+        {
+            try
+            {
+                if (key == null)
+                {
+                    return true;
+                }
+
+                byte[] data = Convert.FromBase64String(key);
+                string decodedString = Encoding.UTF8.GetString(data);
+
+                return key.Trim().Length < 19 ||
+                    decodedString.Length < 14;
+            }
+            catch (Exception)
+            {
+                return true;
+            }
+        }
+    }
+}
+

--- a/FiftyOne.Common/KeyUtils.cs
+++ b/FiftyOne.Common/KeyUtils.cs
@@ -28,9 +28,10 @@ namespace FiftyOne.Common
     public static class KeyUtils
     {
         /// <summary>
-        /// Checks if the supplied 51Degrees resource key / license key is invalid.
-        /// Note that this cannot determine if the key is definitely valid, just whether it is
-        /// definitely invalid.
+        /// Checks if the supplied 51Degrees resource key / license key is
+        /// invalid.
+        /// Note that this cannot determine if the key is definitely valid,
+        /// just whether it is definitely invalid.
         /// </summary>
         /// <param name="key">
         /// The key to check.
@@ -58,4 +59,3 @@ namespace FiftyOne.Common
         }
     }
 }
-


### PR DESCRIPTION
### Changes

- Created FiftyOne.Common.FileUtils class with FindFile method. Created FiftyOne.Common.KeyUtils class with IsInvalidKey method. Created FiftyOne.Common.TestHelpers.TestUtils class with GetFilePath method, which contains test-specific file existence checking logic (using Assert.Inconclusive).

See Issue https://github.com/51Degrees/ip-intelligence-dotnet/issues/75