### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/FiftyOne.Common.TestHelpers/FiftyOne.Common.TestHelpers.csproj
+++ b/FiftyOne.Common.TestHelpers/FiftyOne.Common.TestHelpers.csproj
@@ -17,7 +17,7 @@
     <Copyright>51Degrees Mobile Experts Limited</Copyright>
     <PackageTags>51degrees</PackageTags>
     <RepositoryUrl>https://github.com/51Degrees/common-dotnet</RepositoryUrl>
-    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=common-dotnet&amp;utm_content=fiftyone.common.testhelpers-fiftyone.common.testhelpers.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/FiftyOne.Common/FiftyOne.Common.csproj
+++ b/FiftyOne.Common/FiftyOne.Common.csproj
@@ -17,7 +17,7 @@
     <Copyright>51Degrees Mobile Experts Limited</Copyright>
     <PackageTags>51degrees</PackageTags>
     <RepositoryUrl>https://github.com/51Degrees/common-dotnet</RepositoryUrl>
-    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=common-dotnet&amp;utm_content=fiftyone.common-fiftyone.common.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![51Degrees](https://raw.githubusercontent.com/51Degrees/common-ci/main/images/logo/360x67.png "Data rewards the curious") **Common Dotnet**
 
-[Developer Documentation](https://51degrees.com/pipeline-dotnet/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=dotnet-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/pipeline-dotnet/index.html?utm_source=github&utm_medium=readme&utm_campaign=common-dotnet&utm_content=readme.md&utm_term=fiftyone-common "developer documentation")
 
 [![NuGet](https://img.shields.io/nuget/v/FiftyOne.Common.svg)](https://www.nuget.org/packages/FiftyOne.Common)
 


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

3 links across 4 files, in-place URL replacements only. While tagging, http, www, and protocol-relative variants were normalised to https on the bare domain, pre-2026 utm schemes were replaced, and the retired Logo.ashx banner URL was replaced with img/logo.png where present. Functional endpoints (cloud, distributor, devices-v4, bulkdata), test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).